### PR TITLE
Fix authentication

### DIFF
--- a/ranking/authentication.go
+++ b/ranking/authentication.go
@@ -1,11 +1,10 @@
 package ranking
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
+	"strings"
 
 	"github.com/Epiteks/Epirank/config"
 	"github.com/Epiteks/Epirank/ranking/urls"
@@ -20,13 +19,11 @@ func Authentication(authentication *config.Authentication) error {
 	authenticationData.Add("password", authentication.Password)
 
 	// Create POST request with required header and data
-	request, err := http.NewRequest("POST", urls.EpitechIntranet+"/?format=json", bytes.NewBufferString(authenticationData.Encode()))
-	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Add("Content-Length", strconv.Itoa(len(authenticationData.Encode())))
-
+	request, err := http.NewRequest("POST", urls.EpitechIntranet+"/?format=json", strings.NewReader(authenticationData.Encode()))
 	if err != nil {
 		return err
 	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	client := &http.Client{}
 	resp, err := client.Do(request)
@@ -37,7 +34,7 @@ func Authentication(authentication *config.Authentication) error {
 	defer resp.Body.Close()
 
 	for _, element := range resp.Cookies() {
-		if element.Name == "PHPSESSID" {
+		if element.Name == "user" {
 			authentication.Token = element.Value
 		}
 	}

--- a/ranking/requests.go
+++ b/ranking/requests.go
@@ -3,12 +3,13 @@ package ranking
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Epiteks/Epirank/config"
-	"github.com/Epiteks/Epirank/models"
-	"github.com/Epiteks/Epirank/ranking/urls"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+
+	"github.com/Epiteks/Epirank/config"
+	"github.com/Epiteks/Epirank/models"
+	"github.com/Epiteks/Epirank/ranking/urls"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -164,12 +165,14 @@ func requestGpa(id int, token string, jobs <-chan *models.Student, results chan<
 
 		if err != nil {
 			log.Error(err)
+			return
 		}
 
 		client := &http.Client{}
 		resp, err := client.Do(request)
 		if err != nil {
 			log.Error(err)
+			return
 		}
 
 		defer resp.Body.Close()


### PR DESCRIPTION
- Epitech changes the cookie name which store the token from `PHPSESSID` to `user `.
- Removes the "Content-Length" header, it is done by the standard library.
- Set the header in request after the check of its creation.