### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
-FROM golang:alpine
+FROM golang:1.8-alpine
 
-ADD . /go/src/github.com/Epiteks/Epirank
+WORKDIR /go/src/github.com/Epiteks/Epirank
 
-RUN apk add --update alpine-sdk
+COPY . .
 
-RUN go get -u github.com/Sirupsen/logrus
-RUN go get -u github.com/mattn/go-sqlite3
-RUN go get -u github.com/gin-gonic/gin
+RUN apk add --no-cache git \
+    && go get -d -v . \
+    && apk del git
 
-RUN go install github.com/Epiteks/Epirank
+# RUN apk add --update alpine-sdk
 
-ENTRYPOINT /go/bin/Epirank
+RUN apk add --no-cache gcc libc-dev \
+    && go build . \
+    && apk del gcc libc-dev
+
+FROM alpine:3.6 
+
+COPY --from=0 /go/src/github.com/Epiteks/Epirank/Epirank .
+
+ENTRYPOINT ["/Epirank"]
 
 EXPOSE 8080


### PR DESCRIPTION
It goes from 549mb to 23mb. The image is built in two steps, one is used to build Epirank and one to run the program.

<img width="875" alt="screen shot 2017-07-27 at 14 31 28" src="https://user-images.githubusercontent.com/13218305/28670322-6c059ed4-72d8-11e7-8a78-bf6e635ea8f3.png">
